### PR TITLE
Fixes #24 #25 Ansible + Packer, shutdown button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv
+.venv
+
+packer/output-raspbian

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,75 @@
+
+# Donkey Car Ansible installation book for raspbery pi
+
+This book can be used in 2 different ways :
+
+* deploy it on a running raspberry pi thought SSH, your raspberry pi needs internet access and should be connected to the same network as your host computer
+* build a raspbian image based on this book, you should then take a look at our [packer instructions](../README.md)
+
+## Deploys book on a booted raspberry pi
+
+### Requirements
+
+Install Ansible :
+```
+python3 -m venv venv
+source venv/bin/activate
+pip install Ansible
+```
+
+Install sshpass as we will use ssh with user/password access :
+```bash
+sudo apt-get install sshpass
+```
+
+Flash raspbian on your raspberry pi SD card :
+```bash
+cd /tmp
+curl https://downloads.raspberrypi.org/raspios_oldstable_lite_armhf/images/raspios_oldstable_lite_armhf-2021-12-02/2021-12-02-raspios-buster-armhf-lite.zip -o 2021-12-02-raspios-buster-armhf-lite.zip
+unzip 2021-12-02-raspios-buster-armhf-lite.zip
+# Find your DEVICE_NAME
+lsblk #
+export DEVICE_NAME=/dev/YOUR_DEVICE_NAME
+sudo dd if=2021-12-02-raspios-buster-armhf-lite.img of=$DEVICE_NAME bs=4MB status=progress && sync
+```
+
+Enable SSH, re-insert the SD card on your computeur go to the /boot partition and create `ssh` file :
+```bash
+touch ssh
+```
+
+Insert your SD card on the raspberry pi, plugin ethernet connexion, wait for 2-3 min (as the raspberry pi reboot at first startup to expend it's partition). Then try to reach it using :
+```bash
+ping raspberrypi.local
+```
+
+### Play book on the booted raspberry pi
+
+Frist ensure you don't have any existing key fingerprint associated to `raspberrypi.local`, remove then using :
+```bash
+ssh-keygen -f ~/.ssh/known_hosts -R "raspberrypi.local"
+```
+
+Use the following command inside this folder and in your virtualenv, we will ping the `dev` inventory :
+```bash
+$ ansible dev -i hosts -m ping
+raspberrypi.local | SUCCESS => {
+    "ansible_facts": {
+        "discovered_interpreter_python": "/usr/bin/python3"
+    },
+    "changed": false,
+    "ping": "pong"
+}
+```
+
+Run the book :
+```bash
+ansible-playbook -i hosts -l dev donkeycar.yml
+```
+
+### Play book on multiple raspberry pi / donkeycars at the same time
+
+Take a look as the `hosts` file, reference all your raspberry pi IPs or hostnames in the `[cars]` section. Then run :
+```
+ansible-playbook -i hosts -l cars donkeycar.yml
+```

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -4,7 +4,7 @@
 This book can be used in 2 different ways :
 
 * deploy it on a running raspberry pi thought SSH, your raspberry pi needs internet access and should be connected to the same network as your host computer
-* build a raspbian image based on this book, you should then take a look at our [packer instructions](../README.md)
+* build a raspbian image based on this book, you should then take a look at our [packer instructions](../packer/README.md)
 
 ## Deploys book on a booted raspberry pi
 

--- a/ansible/donkeycar.yml
+++ b/ansible/donkeycar.yml
@@ -1,0 +1,10 @@
+---
+# This playbook deploys the whole DonkeyCar framework.
+
+- name: apply common configuration to all cars
+  hosts: all
+  remote_user: pi
+
+  roles:
+    - role: shutdown-btn
+      become: yes # This role need root privileges

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,0 +1,4 @@
+---
+# Variables listed here are applicable to all cars
+
+shutdown_pin: 29 # Ping no 40, GPIO 21. See wireringpi layout pin numbers here : https://fr.pinout.xyz/pinout/wiringpi#

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,0 +1,10 @@
+[cars]
+dababycar.local
+monkecar.local
+bluecar.local
+
+[dev]
+raspberrypi.local ansible_ssh_common_args='-o StrictHostKeyChecking=no' ansible_user=pi ansible_password=raspberry
+
+[local]
+controlmachine ansible_connection=local

--- a/ansible/roles/shutdown-btn/defaults/main.yml
+++ b/ansible/roles/shutdown-btn/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Defaults variables for shutdown-btn
+shutdown_btn_script_path: /usr/local/pin-shutdown.sh # Brest place according to https://unix.stackexchange.com/a/132725

--- a/ansible/roles/shutdown-btn/handlers/main.yml
+++ b/ansible/roles/shutdown-btn/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# Shutdown-btn handlers
+
+- name: Start button-shutdown service
+  service:
+    name: button-shutdown
+    state: started
+    enabled: yes

--- a/ansible/roles/shutdown-btn/tasks/main.yml
+++ b/ansible/roles/shutdown-btn/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# This playbook contains shutdown btn install tasks.
+
+- name: Install wiringpi package
+  apt:
+    name: wiringpi
+    state: present
+  tags: shutdown-btn
+
+- name: Install shutdown service script
+  template:
+    src: pin-shutdown.sh.j2
+    dest: "{{ shutdown_btn_script_path }}"
+    mode: u=rwx,g=rx,o=rx
+  tags: shutdown-btn
+
+- name: Copy systemd service file to server
+  template:
+    src: button-shutdown.service.j2
+    dest: /etc/systemd/system/button-shutdown.service
+    owner: root
+    group: root
+  notify:
+    - Start button-shutdown service
+  tags: shutdown-btn

--- a/ansible/roles/shutdown-btn/templates/button-shutdown.service.j2
+++ b/ansible/roles/shutdown-btn/templates/button-shutdown.service.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=button shutdown service
+
+[Service]
+ExecStart={{ shutdown_btn_script_path }}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/shutdown-btn/templates/pin-shutdown.sh.j2
+++ b/ansible/roles/shutdown-btn/templates/pin-shutdown.sh.j2
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+pin={{ shutdown_pin }}  # pin 40 (internal: 21) on raspi layout
+gpio mode "$pin" "in"
+
+while :; do
+	gpio wfi "$pin" rising
+	d_start="$(date +%s)"
+	gpio wfi "$pin" falling
+	d_end="$(date +%s)"
+	delta=$((d_end - d_start))
+	if [ "$delta" -gt "3" ]; then
+		break
+	fi
+done
+
+logger Shutdown button pressed
+shutdown -h now
+

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,36 @@
+# Building custom DonkeyCar Image
+
+## Install packer
+
+* Follow the procedure at : https://www.packer.io/downloads
+* Check that you have the command `packer` in a terminal
+
+For developers :
+* install HCL support extension : https://marketplace.visualstudio.com/items?itemName=wholroyd.HCL
+
+
+## Building the image
+
+Packer ARM plugin need root privileges to run. To build the images use the following commands :
+```bash
+sudo packer init .
+sudo packer build donkeycar.pkr.hcl
+```
+
+Then grab some ☕️☕️☕️
+
+## Testing the image on a raspberry pi
+
+Simply dd the image present in `output-raspbian/image` onto your raspberry pi :
+```bash
+$ lsblk # Find your raspbery pi device name
+...
+sde      8:64   1  29,1G  0 disk 
+├─sde1   8:65   1   256M  0 part /media/benjamin/boot
+└─sde2   8:66   1  28,9G  0 part /media/benjamin/rootfs
+# For me it's /dev/sde, 30 GB sd card
+$ sudo dd if=output-raspbian/image bs=4M of=/dev/sde status=progress && sync
+```
+
+# Current issue
+We didn't manage to use packer Ansible-remote (due to this issue [packer-builder-arm#169](https://github.com/mkaczanowski/packer-builder-arm/issues/169), so we need to install ansible on the raspberry pi it self.

--- a/packer/donkeycar.hcl
+++ b/packer/donkeycar.hcl
@@ -1,0 +1,41 @@
+packer {
+  required_plugins {
+    arm-image = {
+      source  = "github.com/solo-io/arm-image"
+      version = ">= 0.2.5"
+    }
+  }
+}
+
+source "arm-image" "raspbian" {
+  iso_url      = "https://downloads.raspberrypi.org/raspios_oldstable_lite_armhf/images/raspios_oldstable_lite_armhf-2021-12-02/2021-12-02-raspios-buster-armhf-lite.zip"
+  iso_checksum = "9276d71a4793accb4e29ad337f58865fcb92f831716305fc93adf0adb4784129"
+  last_partition_extra_size = 524288000 // Adding 500 Mb to last rpi partition, main rootfs, so that we have space to install stuff
+}
+
+build {
+  sources = ["source.arm-image.raspbian"]
+
+  // Install Ansible, will be removed after
+  provisioner "shell" {
+    inline = [
+      "apt-get update",
+      "apt-get install -y ansible"
+    ]
+  }
+
+  // Launch ansible book
+  provisioner "ansible-local" {
+    // Use temporary installed ansible
+    playbook_dir = "../ansible"
+    playbook_file = "../ansible/donkeycar.yml"
+  }
+
+  // Remove Ansible
+  // provisioner "shell" {
+  //   inline = [
+  //     "apt autoremove ansible"
+  //   ]
+  // }
+
+}


### PR DESCRIPTION
Fixes #24 #25 Ansible + Packer, shutdown button

This PR really needs a good review as it's the basic first step to building the donkey car image.

To test it you need :
* A raspberry Pi with a button on Ping N 40, GPIO 21
* HDMI screen and adaptateur for mini HDMI to HDMI

First try to deploy ansible books using SSH, then build a raspberryPi image with packer and boot on it to test.

PS: I forgot enabling SSH in the Ansible book, so you won't be able to use SSH with the image build with packer+ansible, new role maybe `base` should be created that perform this activation.