### PR TITLE
Resolves #56 : Add a LED indicator

### DIFF
--- a/ansible/roles/raspi-config/tasks/main.yml
+++ b/ansible/roles/raspi-config/tasks/main.yml
@@ -56,10 +56,9 @@
   # Change will be taken into account at restart, it's not an issue as our fixe covers
   # timeout issue at the first boot of the raspberry pi.
 
-- name : create car booting led 
-  ansible.builtin.lineinfile:
-    path: /boot/config.txt
-    state: present
+- name: create car booting led 
+  lineinfile:
+    dest: /boot/config.txt
     line: enable_uart=1
     owner: root
     group: root

--- a/ansible/roles/raspi-config/tasks/main.yml
+++ b/ansible/roles/raspi-config/tasks/main.yml
@@ -55,3 +55,11 @@
   # We won't notify to restart DHCP service because it could cause Ansible deconnexion
   # Change will be taken into account at restart, it's not an issue as our fixe covers
   # timeout issue at the first boot of the raspberry pi.
+
+- name : create car booting led 
+  ansible.builtin.lineinfile:
+    path: /boot/config.txt
+    state: present
+    line: enable_uart=1
+    owner: root
+    group: root


### PR DESCRIPTION
# ✨ Feature :
 - Fixes #56 .
  I've added in `raspi-config` roles the led indicator task to allow to connect a led on the car for show to the user that the car is running

## ✅ Tests : 
- [x] Test manually :
- [x] test with clean image

**ALL TESTS PASSED**