### PR TITLE
:sparkles: Fixes #83 'raspberrypi-image / build' check passed always executed

### DIFF
--- a/.github/workflows/no-raspberrypi-image-build.yml
+++ b/.github/workflows/no-raspberrypi-image-build.yml
@@ -14,4 +14,4 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No raspberrypi images realted files (Ansible or packer) were changed, no build required" '
+      - run: 'echo "No raspberrypi images related files (ansible or packer) were changed, no build required" '

--- a/.github/workflows/no-raspberrypi-image-build.yml
+++ b/.github/workflows/no-raspberrypi-image-build.yml
@@ -1,0 +1,17 @@
+name: raspberrypi-image-build
+
+# Oppossite build of raspberrypi-image-build-needed.yml
+# As to enforce check policy even if no changes were made concerning the images sources files
+# This worflow return green for all non Ansible / Packer related PR so that the enforced check passed
+# See : https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks
+on: 
+  pull_request_target: # Allow from forks, but a condition limit where the forks comes from on the sensitive job
+    paths-ignore:
+    - ansible/**
+    - packer/**
+
+jobs:
+  raspberrypi-image-build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No raspberrypi images realted files (Ansible or packer) were changed, no build required" '

--- a/.github/workflows/no-raspberrypi-image-build.yml
+++ b/.github/workflows/no-raspberrypi-image-build.yml
@@ -1,4 +1,4 @@
-name: raspberrypi-image-build
+name: raspberrypi-image
 
 # Oppossite build of raspberrypi-image-build-needed.yml
 # As to enforce check policy even if no changes were made concerning the images sources files
@@ -11,7 +11,7 @@ on:
     - packer/**
 
 jobs:
-  raspberrypi-image-build:
+  build:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No raspberrypi images realted files (Ansible or packer) were changed, no build required" '

--- a/.github/workflows/raspberrypi-image-build-needed.yml
+++ b/.github/workflows/raspberrypi-image-build-needed.yml
@@ -1,4 +1,4 @@
-name: Build raspberry pi DonkeyCar image
+name: raspberrypi-image-build
 
 # Images are need for QA / tests on a real car
 # Waiting for them to build automatically when someone wants to make a full test/review
@@ -16,7 +16,7 @@ on:
     - packer/**
 
 jobs:
-  packer-build:
+  raspberrypi-image-build:
     # Check the PR if it comes from a fork is a trusted fork or not
     # We also need to check if it's not ourself as pull_request_target is also used for PR coming from origin branches
     if: ${{ github.event_name != 'pull_request_target' || github.event_name == 'pull_request_target' && ( github.event.pull_request.head.repo.owner.login == 'mdl29' || github.event.pull_request.head.repo.owner.login == 'viandoxdev' || github.event.pull_request.head.repo.owner.login == 'benvii' || github.event.pull_request.head.repo.owner.login == 'yannis-mlgrn' ) }}

--- a/.github/workflows/raspberrypi-image-build-needed.yml
+++ b/.github/workflows/raspberrypi-image-build-needed.yml
@@ -1,4 +1,4 @@
-name: raspberrypi-image-build
+name: raspberrypi-image
 
 # Images are need for QA / tests on a real car
 # Waiting for them to build automatically when someone wants to make a full test/review
@@ -16,7 +16,7 @@ on:
     - packer/**
 
 jobs:
-  raspberrypi-image-build:
+  build:
     # Check the PR if it comes from a fork is a trusted fork or not
     # We also need to check if it's not ourself as pull_request_target is also used for PR coming from origin branches
     if: ${{ github.event_name != 'pull_request_target' || github.event_name == 'pull_request_target' && ( github.event.pull_request.head.repo.owner.login == 'mdl29' || github.event.pull_request.head.repo.owner.login == 'viandoxdev' || github.event.pull_request.head.repo.owner.login == 'benvii' || github.event.pull_request.head.repo.owner.login == 'yannis-mlgrn' ) }}


### PR DESCRIPTION
'raspberrypi-image / build' check passed even if no changes were made to Ansible or Packer files