### PR TITLE
:bug: [Car] Fixes #227 IR Laptimer with mutex to prevent None exceptions

### DIFF
--- a/ansible/roles/mycar/files/custom/car/parts/irlaptimer.py
+++ b/ansible/roles/mycar/files/custom/car/parts/irlaptimer.py
@@ -19,6 +19,8 @@ class IrLapTimer(threading.Thread):
         self.last_lap_end_date: Optional[datetime] = None
         self.laps_total = 0
         self.daemon = True
+
+        self.compute_laps_mutex = threading.Lock()
         return
 
     def run(self):
@@ -34,46 +36,64 @@ class IrLapTimer(threading.Thread):
                     last_time_was = event_time_seconds
                     event_datetime = datetime.fromtimestamp(event_time_seconds, tz=timezone.utc)
 
-                    # This is the first time IR are seen, means we only start a lap
-                    if self.laps_total == 0:
+                    # Prevent concurrency on lap setting, like a reset while computing on the rested values
+                    self.compute_laps_mutex.acquire()
+                    try:
+                        # This is the first time IR are seen, means we only start a lap
+                        if self.laps_total == 0:
+                            self.current_start_lap_date = event_datetime
+                            self.logger.debug('[lap nb %i] First lap starting now : %s', self.laps_total,
+                                              self.current_start_lap_date)
+                            self.laps_total += 1
+                            continue
+
+                        # We know we are at the end of a lap and begining of a new one :)
+                        # save the last time when the event was received
+                        self.last_lap_end_date = event_datetime
+                        self.last_lap_start_date = self.current_start_lap_date
                         self.current_start_lap_date = event_datetime
-                        self.logger.debug('[lap nb %i] First lap starting now : %s', self.laps_total,
-                                          self.current_start_lap_date)
+
+                        self.logger.debug('[lap nb %i] last_lap_end_date: %s', self.laps_total, self.last_lap_end_date)
+                        self.logger.debug('[lap nb %i] current_start_lap_date: %s', self.laps_total, self.current_start_lap_date)
+
+                        self.last_lap_duration = (self.last_lap_end_date - self.last_lap_start_date) / timedelta(milliseconds = 1)
+
+                        self.logger.debug('[lap nb %i] last_start_lap_date: %s', self.laps_total, self.last_lap_start_date)
+                        self.logger.info('[lap nb %i] last_lap_duration: %i', self.laps_total, self.last_lap_duration)
+
                         self.laps_total += 1
-                        continue
-
-                    # We know we are at the end of a lap and begining of a new one :)
-                    # save the last time when the event was received
-                    self.last_lap_end_date = event_datetime
-                    self.last_lap_start_date = self.current_start_lap_date
-                    self.current_start_lap_date = event_datetime
-
-                    self.logger.debug('[lap nb %i] last_lap_end_date: %s', self.laps_total, self.last_lap_end_date)
-                    self.logger.debug('[lap nb %i] current_start_lap_date: %s', self.laps_total, self.current_start_lap_date)
-
-                    self.last_lap_duration = (self.last_lap_end_date - self.last_lap_start_date) / timedelta(milliseconds = 1)
-
-                    self.logger.debug('[lap nb %i] last_start_lap_date: %s', self.laps_total, self.last_lap_start_date)
-                    self.logger.info('[lap nb %i] last_lap_duration: %i', self.laps_total, self.last_lap_duration)
-
-                    self.laps_total += 1
+                    finally:
+                        self.compute_laps_mutex.release()
 
 class IrLapTimerPart:
     def __init__(self):
         self.timer = IrLapTimer()
         self.timer.start()
+
     def update(self):
         return
+
     def run_threaded(self, reset_all = False):
         if reset_all:
-            self.timer.current_start_lap_date= None
-            self.timer.last_lap_start_date= None
-            self.timer.last_lap_duration = None
-            self.timer.last_lap_end_date = None
-            self.timer.laps_total = 0
+            self.timer.compute_laps_mutex.acquire()
+            try:
+                self.timer.current_start_lap_date= None
+                self.timer.last_lap_start_date= None
+                self.timer.last_lap_duration = None
+                self.timer.last_lap_end_date = None
+                self.timer.laps_total = 0
+            finally:
+                self.timer.compute_laps_mutex.release()
         current_lap_duration = None
-        if self.timer.current_start_lap_date:
-            current_lap_duration = (datetime.now(timezone.utc) - self.timer.current_start_lap_date) / timedelta(milliseconds = 1)
+
+        self.timer.compute_laps_mutex.acquire()
+        try:
+            if self.timer.current_start_lap_date:
+                current_lap_duration = (datetime.now(timezone.utc) - self.timer.current_start_lap_date) / timedelta(milliseconds = 1)
+        finally:
+            self.timer.compute_laps_mutex.release()
+
         return self.timer.current_start_lap_date, current_lap_duration, self.timer.last_lap_start_date, self.timer.last_lap_duration, self.timer.last_lap_end_date, self.timer.laps_total
+
     def run(self, reset_all = False):
         return self.run_threaded(reset_all)


### PR DESCRIPTION
 Fixes #227 IR Laptimer with mutex to prevent None exceptions using a mutex, without it some values can be reset while a computation is made using them (if the car is in front of the IR tower when reset happens), this crash the part thread.